### PR TITLE
Avoid fitting constant term ("intercept") in linear models

### DIFF
--- a/va.py
+++ b/va.py
@@ -1004,7 +1004,7 @@ def VMLD(of,s):
 		of.write(" some (possibly unwanted) redundancy in the results\n")
 	for i in range(len(s.vibrations)):
 		o=[]
-		regressor=sklm.LinearRegression()
+		regressor=sklm.LinearRegression(fit_intercept=False)
 		regressor.fit(s.S,s.ADM[:,i])
 		r2=np.corrcoef(s.ADM[:,i],regressor.predict(s.S))[0,1]**2
 		exvar=skmt.explained_variance_score(s.ADM[:,i],regressor.predict(s.S))
@@ -1024,7 +1024,9 @@ def VMBLD(of,s):
 		of.write(" some (possibly unwanted) redundancy in the results\n")
 	for i in range(len(s.vibrations)):
 		o=[]
-		regressor=sklm.BayesianRidge(compute_score=True,n_iter=5000)
+		# fit_intercept=False would make more sense but BayesianRidge
+		# performs extremely poor with it
+		regressor=sklm.BayesianRidge(compute_score=True,n_iter=5000,fit_intercept=True)
 		regressor.fit(s.S,s.ADM[:,i])
 		r2=np.corrcoef(s.ADM[:,i],regressor.predict(s.S))[0,1]**2
 		exvar=skmt.explained_variance_score(s.ADM[:,i],regressor.predict(s.S))
@@ -1044,7 +1046,7 @@ def VMARD(of,s):
 		of.write(" some (possibly unwanted) redundancy in the results\n")
 	for i in range(len(s.vibrations)):
 		o=[]
-		regressor=sklm.ARDRegression(compute_score=True,n_iter=5000)
+		regressor=sklm.ARDRegression(compute_score=True,n_iter=5000,fit_intercept=False)
 		regressor.fit(s.S,s.ADM[:,i])
 		r2=np.corrcoef(s.ADM[:,i],regressor.predict(s.S))[0,1]**2
 		exvar=skmt.explained_variance_score(s.ADM[:,i],regressor.predict(s.S))


### PR DESCRIPTION
By default all linear models in Scikit-learn include constant term called "intercept". However, it makes no sense in the context of vibrational mode interpretation, as atom displacement vectors are not supposed to include translational component.

This change seems to make a slight improvement to the quality of VMARD analysis. In particular, it often eliminates ANGLE and TOR contaminations from high frequency modes which can be expected to be BOND-only. Values of R^2 don't change significantly, and quite often see an improvement.

Interestingly, this change dramatically improves quality of VMLD analysis, so it becomes comparable to VMARD (while being much faster).

On the other hand, it seems like fit_intercept=False completely ruins VMBLD results, so I kept it as True there but made the setting explicit. However, VMBLD performance seems to be poor anyway.